### PR TITLE
fix: post attachments not showing up in feed

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ async function renderFeed(req, res) {
 
 	const uniqTids = _.uniq(postData.map(p => p.tid));
 	const [topicData, { upvotes }, bookmarkStatus] = await Promise.all([
-		topics.getTopicsFields(uniqTids, ['tid', 'numThumbs']),
+		topics.getTopicsFields(uniqTids, ['tid', 'numThumbs', 'mainPid']),
 		posts.getVoteStatusByPostIDs(pagePids, req.uid),
 		posts.hasBookmarked(pagePids, req.uid),
 	]);


### PR DESCRIPTION
Thumbs.load expects mainPid to be passed in via `topicData`.
